### PR TITLE
Make Bar.isStarted/items public

### DIFF
--- a/src/lib/bar.ts
+++ b/src/lib/bar.ts
@@ -9,8 +9,8 @@ export interface IOptions {
 }
 
 export class Bar {
-  protected items: IBarItem[] = [];
-  protected isStarted = false;
+  public items: IBarItem[] = [];
+  public isStarted = false;
   protected nextUpdate: null | Promise<never> = null;
   protected timeOutId: NodeJS.Timeout | undefined;
 


### PR DESCRIPTION
For `Bar.isStarted`, I start the bar until all the sub-bars get ready and this property is helpful for `if (!bar.isStarted) bar.start()`.

For `Bar.items`, I leave finished bars on screen and reuse them when new bars are needed, and this property is helpful for searching the items.